### PR TITLE
ajustando botões que haviam sumido dentro do modal

### DIFF
--- a/jogo-page.html
+++ b/jogo-page.html
@@ -105,6 +105,10 @@
           </dl>
         </div>
       </div>
+      <div class="game-container">
+        <button class="btn-secondary decorated-btn">Comprar Agora</button>
+        <button class="btn-cart">Adicionar ao carrinho</button>
+      </div>
       <div class="modal" tabindex="-1" id="gamedetail">
         <div class="modal-dialog modal-dialog-centered modal-lg">
           <div class="modal-content">
@@ -117,10 +121,6 @@
             </div>            
           </div>
         </div>
-      <div class="game-container">
-        <button class="btn-secondary decorated-btn">Comprar Agora</button>
-        <button class="btn-cart">Adicionar ao carrinho</button>
-      </div>
     </main>
     <footer class="footer">
       <address class="footer-info">


### PR DESCRIPTION
Ajustando os botões de 'adicionar carrinho e preço' que haviam sumido por estar dentro do modal

Antes
![image 10](https://github.com/user-attachments/assets/600d4060-080d-4acd-a022-f8f4d40c0f57)

Depois
![image](https://github.com/user-attachments/assets/86ecaf8e-7f7a-4fe3-bf57-4e16b45533b8)

